### PR TITLE
Sorting bug fix for VersionDependencies

### DIFF
--- a/QModManager/Patching/ManifestValidator.cs
+++ b/QModManager/Patching/ManifestValidator.cs
@@ -144,6 +144,8 @@
                     {
                         versionedDependencies.Add(new RequiredQMod(item.Key));
                     }
+
+                    mod.RequiredDependencies.Add(item.Key);
                 }
 
                 mod.RequiredMods = versionedDependencies;


### PR DESCRIPTION
- Ensuring that entries from VersionDependencies end up in RequiredDependencies
- Necessary for proper sorting in SortedCollection