### PR TITLE
Fix logging required mods

### DIFF
--- a/QModManager/Patching/ManifestValidator.cs
+++ b/QModManager/Patching/ManifestValidator.cs
@@ -61,10 +61,10 @@
                     mod.SupportedGame = QModGame.Subnautica;
                     break;
                 default:
-                    {
-                        mod.Status = ModStatus.FailedIdentifyingGame;
-                        return;
-                    }
+                {
+                    mod.Status = ModStatus.FailedIdentifyingGame;
+                    return;
+                }
             }
 
             try

--- a/QModManager/Patching/ManifestValidator.cs
+++ b/QModManager/Patching/ManifestValidator.cs
@@ -61,10 +61,10 @@
                     mod.SupportedGame = QModGame.Subnautica;
                     break;
                 default:
-                {
-                    mod.Status = ModStatus.FailedIdentifyingGame;
-                    return;
-                }
+                    {
+                        mod.Status = ModStatus.FailedIdentifyingGame;
+                        return;
+                    }
             }
 
             try
@@ -144,19 +144,20 @@
             }
 
             mod.RequiredMods = requiredMods.Values;
+
             if (Logger.DebugLogsEnabled)
             {
                 string GetModList(IEnumerable<string> modIds)
                 {
-                    string message = string.Empty;
+                    string modList = string.Empty;
                     foreach (var id in modIds)
-                        message += $"{id} ";
+                        modList += $"{id} ";
 
-                    return message;
+                    return modList;
                 }
 
                 if (requiredMods.Count > 0)
-                    Logger.Debug($"{mod.Id} has required mods: {GetModList(requiredMods.Values.Cast<string>())}");
+                    Logger.Debug($"{mod.Id} has required mods: {GetModList(mod.RequiredMods.Select(mod => mod.Id))}");
 
                 if (mod.LoadBeforePreferences.Count > 0)
                     Logger.Debug($"{mod.Id} should load before: {GetModList(mod.LoadBeforePreferences)}");


### PR DESCRIPTION
Updated the logging of RequiredMods with Debug Logs enabled so as not to throw errors. 

Yes @PrimeSonic, I know it uses LINQ, but it also means its less code-reproduction, and its only on load, and only if Debug Logs are enabled... Take the performance cost ;)