### PR TITLE
Aggressively add try{}catch blocks to our preloader patchers

### DIFF
--- a/QMMHarmonyShimmer/QMMHarmonyShimmer.cs
+++ b/QMMHarmonyShimmer/QMMHarmonyShimmer.cs
@@ -33,9 +33,18 @@ namespace QModManager.QMMHarmonyShimmer
         [Obsolete("Should not be used!", true)]
         public static void Initialize()
         {
-            ApplyHarmonyPatches();
-            InitAssemblyResolver();
-            ApplyShims();
+            try
+            {
+                ApplyHarmonyPatches();
+                InitAssemblyResolver();
+                ApplyShims();
+            }
+            catch (Exception ex)
+            {
+                Logger.LogFatal($"An exception occurred while attempting to apply Harmony shims: {ex.Message}.");
+                Logger.LogFatal($"Beginning stacktrace:");
+                Logger.LogFatal(ex.StackTrace);
+            }
         }
 
         private static void ApplyHarmonyPatches()
@@ -234,12 +243,21 @@ namespace QModManager.QMMHarmonyShimmer
         [Obsolete("Should not be used!", true)]
         public static void Finish()
         {
-            AppDomain.CurrentDomain.AssemblyResolve += (sender, resolveEventArgs) =>
+            try
             {
-                return new AssemblyName(resolveEventArgs.Name).Name == "0Harmony_Shim" // Redirect references to the shim to this assembly,
-                    ? Assembly.GetExecutingAssembly()                                  // since we are emulating the API.
-                    : null;
-            };
+                AppDomain.CurrentDomain.AssemblyResolve += (sender, resolveEventArgs) =>
+                {
+                    return new AssemblyName(resolveEventArgs.Name).Name == "0Harmony_Shim" // Redirect references to the shim to this assembly,
+                        ? Assembly.GetExecutingAssembly()                                  // since we are emulating the API.
+                        : null;
+                };
+            }
+            catch (Exception ex)
+            {
+                Logger.LogFatal($"An exception occurred while attempting to apply Harmony shims: {ex.Message}.");
+                Logger.LogFatal($"Beginning stacktrace:");
+                Logger.LogFatal(ex.StackTrace);
+            }
         }
 
         /// <summary>

--- a/QModPluginEmulator/QModPluginGenerator.cs
+++ b/QModPluginEmulator/QModPluginGenerator.cs
@@ -46,12 +46,21 @@ namespace QModManager
         [Obsolete("Should not be used!", true)]
         public static void Finish()
         {
-            PluginCache = GetPluginCache();
-            var harmony = new Harmony("QModManager.QModPluginGenerator");
-            harmony.Patch(
-                typeof(TypeLoader).GetMethod(nameof(TypeLoader.FindPluginTypes)).MakeGenericMethod(typeof(PluginInfo)),
-                postfix: new HarmonyMethod(typeof(QModPluginGenerator).GetMethod(nameof(TypeLoaderFindPluginTypesPostfix))));
-            harmony.PatchAll(typeof(QModPluginGenerator));
+            try
+            {
+                PluginCache = GetPluginCache();
+                var harmony = new Harmony("QModManager.QModPluginGenerator");
+                harmony.Patch(
+                    typeof(TypeLoader).GetMethod(nameof(TypeLoader.FindPluginTypes)).MakeGenericMethod(typeof(PluginInfo)),
+                    postfix: new HarmonyMethod(typeof(QModPluginGenerator).GetMethod(nameof(TypeLoaderFindPluginTypesPostfix))));
+                harmony.PatchAll(typeof(QModPluginGenerator));
+            }
+            catch (Exception ex)
+            {
+                Logger.LogFatal($"An exception occurred while attempting to generate BepInEx PluginInfos: {ex.Message}.");
+                Logger.LogFatal($"Beginning stacktrace:");
+                Logger.LogFatal(ex.StackTrace);
+            }
         }
 
         private static string[] QMMKnownAssemblyPaths = new[] {


### PR DESCRIPTION
Attempting to catch obscure errors in preloader patches to prevent our preloader patches from cancelling QMM load.