### PR TITLE
QMMHarmonyShimmer: Improved logging for invalid assemblies

### DIFF
--- a/QMMHarmonyShimmer/QMMHarmonyShimmer.cs
+++ b/QMMHarmonyShimmer/QMMHarmonyShimmer.cs
@@ -218,10 +218,21 @@ namespace QModManager.QMMHarmonyShimmer
                             }
                         }
                     }
+                    catch (BadImageFormatException)
+                    {
+                        if (Path.GetFileName(filePath).Contains("0Harmony"))
+                            Logger.LogWarning($"QMod in folder {Path.GetDirectoryName(subfolderPath)} is shipping its own version of Harmony! " +
+                                $"This is NOT RECOMMENDED and can lead to serious compatibility issues with other mods! " +
+                                $"If you are a mod author, please do not ship Harmony with your mods, and instead rely on QModManager to load it for you.");
+                        else
+                            Logger.LogInfo($"Cannot shim {Path.GetFileName(filePath)} as it is not a valid assembly, skipping...");
+                        continue;
+                    }
                     catch (Exception e)
                     {
                         Logger.LogError($"Failed to shim {Path.GetFileName(filePath)}");
                         Logger.LogError(e);
+                        continue;
                     }
                 }
             }

--- a/QMMHarmonyShimmer/QMMHarmonyShimmer.cs
+++ b/QMMHarmonyShimmer/QMMHarmonyShimmer.cs
@@ -40,7 +40,7 @@ namespace QModManager.QMMHarmonyShimmer
 
         private static void ApplyHarmonyPatches()
         {
-            var harmony = new HarmonyLib.Harmony("QMMLoader");
+            var harmony = new HarmonyLib.Harmony("QMMHarmonyShimmer");
             harmony.PatchAll();
         }
 

--- a/QMMHarmonyShimmer/QMMHarmonyShimmer.cs
+++ b/QMMHarmonyShimmer/QMMHarmonyShimmer.cs
@@ -222,8 +222,10 @@ namespace QModManager.QMMHarmonyShimmer
                     {
                         if (Path.GetFileName(filePath).Contains("0Harmony"))
                             Logger.LogWarning($"QMod in folder {Path.GetDirectoryName(subfolderPath)} is shipping its own version of Harmony! " +
-                                $"This is NOT RECOMMENDED and can lead to serious compatibility issues with other mods! " +
-                                $"If you are a mod author, please do not ship Harmony with your mods, and instead rely on QModManager to load it for you.");
+                                "This is NOT RECOMMENDED and can lead to serious compatibility issues with other mods! " +
+                                "If you are a mod author, please do not ship Harmony with your mods, " +
+                                $"and instead rely on QModManager to load it for you. For more details, see the wiki:{Environment.NewLine}" +
+                                "https://github.com/SubnauticaModding/QModManager/wiki/Basic-ModLoading-Setup-(Basics)");
                         else
                             Logger.LogInfo($"Cannot shim {Path.GetFileName(filePath)} as it is not a valid assembly, skipping...");
                         continue;


### PR DESCRIPTION
- Spefically catching the `BadImageFormatException` thrown when we attempt to shim an assembly that is not a valid format (ie. unmanaged) and improved logging for this.

- Also added log warnings when any version of `0Harmony.dll` is detected in a QMod subfolder to allow users, modders and support-staff alike to know that this will very likely cause issues and the mod should be updated or removed.

Closes #176 