### PR TITLE
Launch From Exe

### DIFF
--- a/QMMLoader/QMMLoader.cs
+++ b/QMMLoader/QMMLoader.cs
@@ -44,7 +44,7 @@ namespace QModManager
         }
 
         private static Harmony harmony;
-        private static MethodInfo entryPointTarget = AccessTools.Method(typeof(GameInput), nameof(GameInput.Awake));
+        private static MethodInfo entryPointTarget = AccessTools.Method(typeof(PlatformUtils), nameof(PlatformUtils.PlatformInitAsync));
         private static MethodInfo entryPointPatch = AccessTools.Method(typeof(QMMLoader), nameof(QMMLoader.InitializeQModManager));
         private void Initialize()
         {


### PR DESCRIPTION
This change now makes QMM work when launching from the EXE as well as from the launcher.

Changes the Harmony Patch location in QMMLoader from GameInput.Awake to PlatformUtils.PlatformInitAsyc which causes QMM to not start making its changes until after the game has been restarted if it needs to be.