### PR TITLE
Ignore obsolete mods

### DIFF
--- a/QModManager/Patching/ManifestValidator.cs
+++ b/QModManager/Patching/ManifestValidator.cs
@@ -18,6 +18,8 @@
             { "QModManager", ModStatus.BannedID },
             { "QModInstaller", ModStatus.BannedID },
             { "EnableAchievements", ModStatus.Merged },
+            { "AgonyAssetTools", ModStatus.Obsolete },
+            { "qmultimod.mod", ModStatus.Obsolete },
         };
 
         public void ValidateBasicManifest(QMod mod)

--- a/QModManager/Patching/ModStatus.cs
+++ b/QModManager/Patching/ModStatus.cs
@@ -2,6 +2,7 @@
 {
     internal enum ModStatus
     {
+        Obsolete = -4,
         Merged = -3,
         //CanceledByAuthor = -2,
         CanceledByUser = -1,

--- a/QModManager/Utility/SummaryLogger.cs
+++ b/QModManager/Utility/SummaryLogger.cs
@@ -32,6 +32,7 @@
             LogStatus(mods, ModStatus.UnidentifiedMod, "The following mods could not be identified for loading:", Logger.Level.Error);
             LogStatus(mods, ModStatus.BannedID, "The following mods could not be loaded because they are using a banned ID:", Logger.Level.Error);
             LogStatus(mods, ModStatus.Merged, "The following mods have been merged with QModManager and have been skipped:", Logger.Level.Warn);
+            LogStatus(mods, ModStatus.Obsolete, "The following mods are obsolete and have been skipped:", Logger.Level.Warn);
         }
 
         private static void LogStatus(List<QMod> mods, ModStatus statusToReport, string summary, Logger.Level logLevel)


### PR DESCRIPTION
Added new `ModStatus`: `ModStatus.Obsolete` for mods so outdated they are no longer supported and will be skipped during the mod loading process.

Added 2 mods to the `ProhibitedModIDs` dictionary in `ManifestValidator.cs` with this new `Obsolete` status:
- AssetTools (`AgonyAssetTools`): Known to be breaking mod options menus for many, many mods. Every mod that every used it is basically dead and/or replaced by another mod.
- QMultiMod (`qmultimod.mod`): Supplanted by several other mods, basically never used, causing compatibility issues with mods that have replaced it.

Added appropriate logging when mods with the `Obsolete` status are skipped.