### PR TITLE
Update PirateCheck.cs

### DIFF
--- a/QModManager/Checks/PirateCheck.cs
+++ b/QModManager/Checks/PirateCheck.cs
@@ -17,6 +17,7 @@ namespace QModManager.Checks
             "steam_api64.ini",
             "steam_emu.ini",
             "valve.ini",
+            "SmartSteamEmu.ini",
             "Subnautica_Data/Plugins/steam_api64.cdx",
             "Subnautica_Data/Plugins/steam_api64.ini",
             "Subnautica_Data/Plugins/steam_emu.ini",


### PR DESCRIPTION
Adds logger text for SmartSteamEmu. Currently you only checked for goldberg. They are about equal in popularity.