### PR TITLE
3 Updates (Pirate,TimestampUpdate,SteamCloud)

### DIFF
--- a/QModManager/Checks/PirateCheck.cs
+++ b/QModManager/Checks/PirateCheck.cs
@@ -21,6 +21,10 @@ namespace QModManager.Checks
             "Subnautica_Data/Plugins/steam_api64.cdx",
             "Subnautica_Data/Plugins/steam_api64.ini",
             "Subnautica_Data/Plugins/steam_emu.ini",
+            "Profile/SteamUserID.cfg",
+            "Profile/Stats/Achievements.Bin",
+            "launcher.bat",
+            "chuj.cdx",
         };
 
         internal static void IsPirate(string folder)

--- a/QModManager/Patching/GameDetector.cs
+++ b/QModManager/Patching/GameDetector.cs
@@ -56,7 +56,7 @@
 
             Logger.Info($"Game Version: {SNUtils.GetPlasticChangeSetOfBuild()} Build Date: {SNUtils.GetDateTimeOfBuild():dd-MMMM-yyyy}");
             Logger.Info($"Loading QModManager v{Assembly.GetExecutingAssembly().GetName().Version.ToStringParsed()}{(IsValidGameRunning && MinimumBuildVersion != 0 ? $" built for {CurrentlyRunningGame} v{MinimumBuildVersion}" : string.Empty)}...");
-            Logger.Info($"Today is {DateTime.Today:dd-MMMM-yyyy}");
+            Logger.Info($"Today is {DateTime.Today:dd-MMMM-yyyy_HH:mm:ss}");
 
             CurrentGameVersion = SNUtils.GetPlasticChangeSetOfBuild(-1);
             if (!IsValidGameVersion)

--- a/QModManager/Utility/IOUtilities.cs
+++ b/QModManager/Utility/IOUtilities.cs
@@ -21,6 +21,8 @@ namespace QModManager.Utility
             "SubnauticaZero_Data",
             "_CommonRedist",
             "steam_shader_cache",
+            "SavesDir",
+            "SavesDir2",
         };
 
         internal static void LogFolderStructureAsTree(string directory = null)


### PR DESCRIPTION
1. Updated the list of Piracy indicating Files.
2. Update the Timestamp to show the current clocktime to make it easier to indicate multiple Logfilke of the same person when providing help.
3. BZ introduce Steam Cloud Sync. I don't think we need that files to show up in the logfile.