### PR TITLE
Applying a Regex to trim out the dirty string patterns instead

### DIFF
--- a/QModPluginEmulator/QModPluginGenerator.cs
+++ b/QModPluginEmulator/QModPluginGenerator.cs
@@ -6,7 +6,7 @@ using Mono.Cecil;
 #if SUBNAUTICA_STABLE
 using Oculus.Newtonsoft.Json;
 #else
-    using Newtonsoft.Json;
+using Newtonsoft.Json;
 #endif
 using QModManager.API;
 using QModManager.Patching;
@@ -83,13 +83,13 @@ namespace QModManager
             }
         }
 
-        public static List<string> DirtyStartStrings = new List<string>()
+        private readonly static List<string> DirtyStartStrings = new List<string>()
         {
             "Resetting cell with", "Replacing cell",
             "PerformGarbage", "Fallback handler could not load"
         };
 
-        public static List<string> DirtyPatterns = new List<string>()
+        private readonly static List<string> DirtyPatterns = new List<string>()
         {
             @"[\r\n]+(\(Filename: .*\))"
         };
@@ -162,7 +162,7 @@ namespace QModManager
 #elif BELOWZERO
         private static void InitializeQMM()
         {
-            if(ModsToLoad != null)
+            if (ModsToLoad != null)
             {
                 Initializer.InitializeMods(ModsToLoad, PatchingOrder.NormalInitialize);
                 Initializer.InitializeMods(ModsToLoad, PatchingOrder.PostInitialize);
@@ -171,7 +171,7 @@ namespace QModManager
                 SummaryLogger.ReportIssues(ModsToLoad);
                 SummaryLogger.LogSummaries(ModsToLoad);
 
-                foreach(Dialog dialog in Patcher.Dialogs)
+                foreach (Dialog dialog in Patcher.Dialogs)
                 {
                     dialog.Show();
                 }

--- a/QModPluginEmulator/QModPluginGenerator.cs
+++ b/QModPluginEmulator/QModPluginGenerator.cs
@@ -83,27 +83,20 @@ namespace QModManager
             }
         }
 
-        private readonly static List<string> DirtyStartStrings = new List<string>()
-        {
-            "Resetting cell with", "Replacing cell",
-            "PerformGarbage", "Fallback handler could not load"
-        };
-
         private readonly static List<Regex> DirtyRegexPatterns = new List<Regex>() {
-            new Regex(@"[\r\n]+(\(Filename: .*\))", RegexOptions.Compiled)
+            new Regex(@"([\r\n]+)?(\(Filename: .*\))$", RegexOptions.Compiled | RegexOptions.Multiline),
+            new Regex(@"^(Replacing cell.*)$", RegexOptions.Compiled | RegexOptions.Multiline),
+            new Regex(@"^(Resetting cell with.*)$", RegexOptions.Compiled | RegexOptions.Multiline),
+            new Regex(@"^(PerformGarbage.*)$", RegexOptions.Compiled | RegexOptions.Multiline),
+            new Regex(@"^(Fallback handler could not load.*)$", RegexOptions.Compiled | RegexOptions.Multiline),
+            new Regex(@"^(Heartbeat CSV.*,[0-9])$", RegexOptions.Compiled | RegexOptions.Multiline),
+            new Regex(@"^(L0: PerformGarbageCollection ->.*)$", RegexOptions.Compiled | RegexOptions.Multiline),
+            new Regex(@"^(L0: CellManager::EstimateBytes.*)$", RegexOptions.Compiled | RegexOptions.Multiline),
+            new Regex(@"^(Kinematic body only supports Speculative Continuous collision detection.*)$", RegexOptions.Compiled | RegexOptions.Multiline),
         };
 
         private static void LibcHelper_Format_Postfix(ref string __result)
         {
-            foreach (string dirtyString in DirtyStartStrings)
-            {
-                if (__result.StartsWith(dirtyString))
-                {
-                    __result = string.Empty;
-                    return;
-                }
-            }
-
             foreach (Regex pattern in DirtyRegexPatterns)
             {
                 __result = pattern.Replace(__result, string.Empty).Trim();

--- a/QModPluginEmulator/QModPluginGenerator.cs
+++ b/QModPluginEmulator/QModPluginGenerator.cs
@@ -89,9 +89,8 @@ namespace QModManager
             "PerformGarbage", "Fallback handler could not load"
         };
 
-        private readonly static List<string> DirtyPatterns = new List<string>()
-        {
-            @"[\r\n]+(\(Filename: .*\))"
+        private readonly static List<Regex> DirtyRegexPatterns = new List<Regex>() {
+            new Regex(@"[\r\n]+(\(Filename: .*\))", RegexOptions.Compiled)
         };
 
         private static void LibcHelper_Format_Postfix(ref string __result)
@@ -105,10 +104,9 @@ namespace QModManager
                 }
             }
 
-            foreach (string dirtyPattern in DirtyPatterns)
+            foreach (Regex pattern in DirtyRegexPatterns)
             {
-                var regex = new Regex(dirtyPattern);
-                __result = regex.Replace(__result, string.Empty).Trim();
+                __result = pattern.Replace(__result, string.Empty).Trim();
             }
         }
 


### PR DESCRIPTION
Identified a bug with the patch to `MirrorInternalLogs`:

When a log coming from a `BepInEx.Logging.ManualLogSource` comes in directly after one of the mid string trims applied in the patch (e.g. "(Filename: xdgodkdgx)", the patch unfortunately appears to trim both the intended line + the line coming from the `ManualLogSource`, and leaves an empty line behind.

Evidence of this occurring is in the [Fast Loading Screen](https://www.nexusmods.com/subnautica/mods/763) mod. The current release version of QMM for SN.STABLE leaves behind a large amount of empty lines after loading into the game, and Fast Loading Screen's logs are absent.

With the modifications I have made to this patch - which use a `Regex` to strip out occurrences of the intended string - results in the intended behaviour: the garbage line is removed, but no other logs are affected. I have attached an SN.STABLE build of QMM installer from this branch for your testing.

[QModManager_4.1.3_Subnautica_Setup.exe.zip](https://github.com/SubnauticaModding/QModManager/files/6565439/QModManager_4.1.3_Subnautica_Setup.exe.zip)

