### PR TITLE
Resolve BepInEx plugins being destroyed

### DIFF
--- a/Dependencies/BZ.EXP/BepInEx.cfg
+++ b/Dependencies/BZ.EXP/BepInEx.cfg
@@ -13,4 +13,4 @@ Type = PreStartScreen
 ## The name of the method in the specified entrypoint assembly and type to hook and load Chainloader from.
 # Setting type: String
 # Default value: .cctor
-Method = .cctor
+Method = Start

--- a/Dependencies/BZ.EXP/BepInEx.cfg
+++ b/Dependencies/BZ.EXP/BepInEx.cfg
@@ -1,0 +1,16 @@
+[Preloader.Entrypoint]
+
+## The local filename of the assembly to target.
+# Setting type: String
+# Default value: UnityEngine.CoreModule.dll
+Assembly = Assembly-CSharp.dll
+
+## The name of the type in the entrypoint assembly to search for the entrypoint method.
+# Setting type: String
+# Default value: Application
+Type = PreStartScreen
+
+## The name of the method in the specified entrypoint assembly and type to hook and load Chainloader from.
+# Setting type: String
+# Default value: .cctor
+Method = .cctor

--- a/Dependencies/BZ.STABLE/BepInEx.cfg
+++ b/Dependencies/BZ.STABLE/BepInEx.cfg
@@ -13,4 +13,4 @@ Type = PreStartScreen
 ## The name of the method in the specified entrypoint assembly and type to hook and load Chainloader from.
 # Setting type: String
 # Default value: .cctor
-Method = .cctor
+Method = Start

--- a/Dependencies/BZ.STABLE/BepInEx.cfg
+++ b/Dependencies/BZ.STABLE/BepInEx.cfg
@@ -1,0 +1,16 @@
+[Preloader.Entrypoint]
+
+## The local filename of the assembly to target.
+# Setting type: String
+# Default value: UnityEngine.CoreModule.dll
+Assembly = Assembly-CSharp.dll
+
+## The name of the type in the entrypoint assembly to search for the entrypoint method.
+# Setting type: String
+# Default value: Application
+Type = PreStartScreen
+
+## The name of the method in the specified entrypoint assembly and type to hook and load Chainloader from.
+# Setting type: String
+# Default value: .cctor
+Method = .cctor

--- a/Dependencies/SN.EXP/BepInEx.cfg
+++ b/Dependencies/SN.EXP/BepInEx.cfg
@@ -13,4 +13,4 @@ Type = PreStartScreen
 ## The name of the method in the specified entrypoint assembly and type to hook and load Chainloader from.
 # Setting type: String
 # Default value: .cctor
-Method = .cctor
+Method = Start

--- a/Dependencies/SN.EXP/BepInEx.cfg
+++ b/Dependencies/SN.EXP/BepInEx.cfg
@@ -1,0 +1,16 @@
+[Preloader.Entrypoint]
+
+## The local filename of the assembly to target.
+# Setting type: String
+# Default value: UnityEngine.CoreModule.dll
+Assembly = Assembly-CSharp.dll
+
+## The name of the type in the entrypoint assembly to search for the entrypoint method.
+# Setting type: String
+# Default value: Application
+Type = PreStartScreen
+
+## The name of the method in the specified entrypoint assembly and type to hook and load Chainloader from.
+# Setting type: String
+# Default value: .cctor
+Method = .cctor

--- a/Dependencies/SN.STABLE/BepInEx.cfg
+++ b/Dependencies/SN.STABLE/BepInEx.cfg
@@ -1,0 +1,16 @@
+[Preloader.Entrypoint]
+
+## The local filename of the assembly to target.
+# Setting type: String
+# Default value: UnityEngine.CoreModule.dll
+Assembly = Assembly-CSharp.dll
+
+## The name of the type in the entrypoint assembly to search for the entrypoint method.
+# Setting type: String
+# Default value: Application
+Type = SystemsSpawner
+
+## The name of the method in the specified entrypoint assembly and type to hook and load Chainloader from.
+# Setting type: String
+# Default value: .cctor
+Method = Awake

--- a/Installer/BZ.EXP.iss
+++ b/Installer/BZ.EXP.iss
@@ -76,6 +76,7 @@ Source: "QModManager.UnityAudioFixer.xml"; DestDir: "{app}\BepInEx\patchers\QMod
 
 ; BepInEx
 Source: "..\..\Dependencies\BepInEx\*"; DestDir: "{app}"; Flags: recursesubdirs createallsubdirs replacesameversion sharedfile uninsnosharedfileprompt;
+Source: "..\..\Dependencies\BZ.EXP\BepInEx.cfg"; DestDir: "{app}\BepInEx\config"; Flags: ignoreversion sharedfile uninsnosharedfileprompt;
 
 [Dirs]
 Name: "{app}\QMods"

--- a/Installer/BZ.STABLE.iss
+++ b/Installer/BZ.STABLE.iss
@@ -76,6 +76,7 @@ Source: "QModManager.UnityAudioFixer.xml"; DestDir: "{app}\BepInEx\patchers\QMod
 
 ; BepInEx
 Source: "..\..\Dependencies\BepInEx\*"; DestDir: "{app}"; Flags: recursesubdirs createallsubdirs replacesameversion sharedfile uninsnosharedfileprompt;
+Source: "..\..\Dependencies\BZ.STABLE\BepInEx.cfg"; DestDir: "{app}\BepInEx\config"; Flags: ignoreversion sharedfile uninsnosharedfileprompt;
 
 [Dirs]
 Name: "{app}\QMods"

--- a/Installer/SN.EXP.iss
+++ b/Installer/SN.EXP.iss
@@ -76,6 +76,7 @@ Source: "QModManager.UnityAudioFixer.xml"; DestDir: "{app}\BepInEx\patchers\QMod
 
 ; BepInEx
 Source: "..\..\Dependencies\BepInEx\*"; DestDir: "{app}"; Flags: recursesubdirs createallsubdirs replacesameversion sharedfile uninsnosharedfileprompt;
+Source: "..\..\Dependencies\SN.EXP\BepInEx.cfg"; DestDir: "{app}\BepInEx\config"; Flags: ignoreversion sharedfile uninsnosharedfileprompt;
 
 [Dirs]
 Name: "{app}\QMods"

--- a/Installer/SN.STABLE.iss
+++ b/Installer/SN.STABLE.iss
@@ -74,6 +74,7 @@ Source: "QModManager.UnityAudioFixer.xml"; DestDir: "{app}\BepInEx\patchers\QMod
 
 ; BepInEx
 Source: "..\..\Dependencies\BepInEx\*"; DestDir: "{app}"; Flags: recursesubdirs createallsubdirs replacesameversion sharedfile uninsnosharedfileprompt;
+Source: "..\..\Dependencies\SN.STABLE\BepInEx.cfg"; DestDir: "{app}\BepInEx\config"; Flags: ignoreversion sharedfile uninsnosharedfileprompt;
 
 [Dirs]
 Name: "{app}\QMods"

--- a/QModManager/BepInex/Plugins/QMMLoader.cs
+++ b/QModManager/BepInex/Plugins/QMMLoader.cs
@@ -49,13 +49,13 @@ namespace QModInstaller.BepInEx.Plugins
 
         private void PreInitializeQMods()
         {
+            Patcher.Patch(); // Run QModManager patch
+
             if (QModsToLoad is null)
             {
                 Logger.LogWarning("QModsToLoad is null!");
                 return;
             }
-
-            Patcher.Patch(); // Run QModManager patch
 
             Initializer = new Initializer(Patcher.CurrentlyRunningGame);
             Initializer.InitializeMods(QModsToLoad, PatchingOrder.MetaPreInitialize);
@@ -92,28 +92,20 @@ namespace QModInstaller.BepInEx.Plugins
         {
             yield return result;
 
-            if (QModsToLoad != null)
-            {
-                Initializer.InitializeMods(QModsToLoad, PatchingOrder.NormalInitialize);
-                Initializer.InitializeMods(QModsToLoad, PatchingOrder.PostInitialize);
-                Initializer.InitializeMods(QModsToLoad, PatchingOrder.MetaPostInitialize);
+            Initializer.InitializeMods(QModsToLoad, PatchingOrder.NormalInitialize);
+            Initializer.InitializeMods(QModsToLoad, PatchingOrder.PostInitialize);
+            Initializer.InitializeMods(QModsToLoad, PatchingOrder.MetaPostInitialize);
 
-                SummaryLogger.ReportIssues(QModsToLoad);
-                SummaryLogger.LogSummaries(QModsToLoad);
-                foreach (Dialog dialog in Patcher.Dialogs)
-                {
-                    dialog.Show();
-                }
+            SummaryLogger.ReportIssues(QModsToLoad);
+            SummaryLogger.LogSummaries(QModsToLoad);
+            foreach (Dialog dialog in Patcher.Dialogs)
+            {
+                dialog.Show();
             }
         }
 #elif BELOWZERO
         private static void InitializeQMods() 
         {
-            if (QModsToLoad is null)
-            {
-                return;
-            }
-
             Initializer.InitializeMods(QModsToLoad, PatchingOrder.NormalInitialize);
             Initializer.InitializeMods(QModsToLoad, PatchingOrder.PostInitialize);
             Initializer.InitializeMods(QModsToLoad, PatchingOrder.MetaPostInitialize);

--- a/QModManager/QMMLoader.cs
+++ b/QModManager/QMMLoader.cs
@@ -23,7 +23,6 @@ namespace QModInstaller
         internal const string SubnauticaProcessName = "Subnautica";
         internal const string SubnauticaZeroProcessName = "SubnauticaZero";
 
-        [System.NonSerialized]
         internal static List<QMod> QModsToLoad;
         private static Initializer Initializer;
 

--- a/QModManager/QMMLoader.cs
+++ b/QModManager/QMMLoader.cs
@@ -1,8 +1,12 @@
-﻿namespace QModInstaller
+﻿using BepInEx;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace QModInstaller
 {
-    using BepInEx;
-    using System;
-    using UnityEngine;
+    using QModManager.API.ModLoading;
+    using QModManager.Patching;
+    using QModManager.Utility;
 
     /// <summary>
     /// QMMLoader - simply fires up the QModManager entry point.
@@ -10,7 +14,7 @@
     [BepInPlugin(PluginGuid, PluginName, PluginVersion)]
     [BepInProcess(SubnauticaProcessName)]
     [BepInProcess(SubnauticaZeroProcessName)]
-    public class QMMLoader: BaseUnityPlugin
+    public class QMMLoader : BaseUnityPlugin
     {
         internal const string PluginGuid = "QModManager.QMMLoader";
         internal const string PluginName = "QMMLoader";
@@ -19,20 +23,52 @@
         internal const string SubnauticaProcessName = "Subnautica";
         internal const string SubnauticaZeroProcessName = "SubnauticaZero";
 
+        [System.NonSerialized]
+        internal static List<QMod> QModsToLoad;
+        private static Initializer Initializer;
+
         /// <summary>
         /// Prevents a default instance of the <see cref="QMMLoader"/> class from being created 
         /// Also ensures the root bepinex object does not get destroyed if the game reloads for steam.
         /// </summary>
-        [Obsolete("DO NOT USE!", true)]
-        private QMMLoader()
+        private void Awake()
         {
             GameObject obj = gameObject;
 
-            while(obj.transform.parent?.gameObject != null)
+            while (obj.transform.parent?.gameObject != null)
+            {
                 obj = obj.transform.parent.gameObject;
+            }
 
             obj.EnsureComponent<SceneCleanerPreserve>();
             DontDestroyOnLoad(obj);
+
+            InitializeQMods();
+        }
+
+        private void InitializeQMods()
+        {
+            if (QModsToLoad is null)
+            {
+                Logger.LogWarning("QModsToLoad is null!");
+                return;
+            }
+
+            Patcher.Patch(); // Run QModManager patch
+
+            Initializer = new Initializer(Patcher.CurrentlyRunningGame);
+            Initializer.InitializeMods(QModsToLoad, PatchingOrder.MetaPreInitialize);
+            Initializer.InitializeMods(QModsToLoad, PatchingOrder.PreInitialize);
+            Initializer.InitializeMods(QModsToLoad, PatchingOrder.NormalInitialize);
+            Initializer.InitializeMods(QModsToLoad, PatchingOrder.PostInitialize);
+            Initializer.InitializeMods(QModsToLoad, PatchingOrder.MetaPostInitialize);
+
+            SummaryLogger.ReportIssues(QModsToLoad);
+            SummaryLogger.LogSummaries(QModsToLoad);
+            foreach (Dialog dialog in Patcher.Dialogs)
+            {
+                dialog.Show();
+            }
         }
     }
 }

--- a/QModManager/QModManager.csproj
+++ b/QModManager/QModManager.csproj
@@ -108,7 +108,7 @@
       <Private>False</Private>
     </Reference>
   </ItemGroup>
-  <ItemGroup Condition="'$(Configuration)|$(Platform)' == 'BZ.EXP|AnyCPU'">
+  <ItemGroup Condition="'$(Configuration)' == 'BZ.EXP'">
     <Reference Include="Sentry">
       <HintPath>..\Dependencies\$(Configuration)\Sentry.dll</HintPath>
       <Private>False</Private>

--- a/QModManager/QModManager.csproj
+++ b/QModManager/QModManager.csproj
@@ -78,10 +78,6 @@
       <HintPath>..\Dependencies\$(Configuration)\Newtonsoft.Json.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Sentry">
-      <HintPath>..\Dependencies\$(Configuration)\Sentry.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="UnityEngine">
       <HintPath>..\Dependencies\$(Configuration)\UnityEngine.dll</HintPath>
@@ -109,6 +105,12 @@
     </Reference>
     <Reference Include="UnityEngine.UI">
       <HintPath>..\Dependencies\$(Configuration)\UnityEngine.UI.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(Configuration)|$(Platform)' == 'BZ.EXP|AnyCPU'">
+    <Reference Include="Sentry">
+      <HintPath>..\Dependencies\$(Configuration)\Sentry.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/QModPluginEmulator/QModManager.QModPluginGenerator.csproj
+++ b/QModPluginEmulator/QModManager.QModPluginGenerator.csproj
@@ -104,6 +104,7 @@
   <PropertyGroup>
     <PostBuildEvent>rmdir "$(SolutionDir)VortexBuild\$(Configuration)" /q /s
 xcopy "$(SolutionDir)Dependencies\BepInEx" "$(SolutionDir)VortexBuild\$(Configuration)"  /E /H /I /Q /Y
+xcopy "$(SolutionDir)Dependencies\$(Configuration)\BepInEx.cfg" "$(SolutionDir)VortexBuild\$(Configuration)\BepInEx\config\"  /I /Q /Y
 mkdir "$(SolutionDir)VortexBuild\$(Configuration)\QMods"
 xcopy "$(SolutionDir)Dependencies\cldb.dat" "$(SolutionDir)VortexBuild\$(Configuration)\BepInEx\patchers\QModManager\" /I /Q /Y
 xcopy "$(SolutionDir)packages\AssetsTools.NET.2.0.3\lib\net35\AssetsTools.NET.dll" "$(SolutionDir)VortexBuild\$(Configuration)\BepInEx\patchers\QModManager\" /I /Q /Y

--- a/QModPluginEmulator/QModManager.QModPluginGenerator.csproj
+++ b/QModPluginEmulator/QModManager.QModPluginGenerator.csproj
@@ -104,6 +104,7 @@
   <PropertyGroup>
     <PostBuildEvent>rmdir "$(SolutionDir)VortexBuild\$(Configuration)" /q /s
 xcopy "$(SolutionDir)Dependencies\BepInEx" "$(SolutionDir)VortexBuild\$(Configuration)"  /E /H /I /Q /Y
+mkdir "$(SolutionDir)VortexBuild\$(Configuration)\QMods"
 xcopy "$(SolutionDir)Dependencies\cldb.dat" "$(SolutionDir)VortexBuild\$(Configuration)\BepInEx\patchers\QModManager\" /I /Q /Y
 xcopy "$(SolutionDir)packages\AssetsTools.NET.2.0.3\lib\net35\AssetsTools.NET.dll" "$(SolutionDir)VortexBuild\$(Configuration)\BepInEx\patchers\QModManager\" /I /Q /Y
 xcopy "$(TargetDir)QModManager.exe" "$(SolutionDir)VortexBuild\$(Configuration)\BepInEx\patchers\QModManager\"   /I /Q /Y

--- a/QModPluginEmulator/QModManager.QModPluginGenerator.csproj
+++ b/QModPluginEmulator/QModManager.QModPluginGenerator.csproj
@@ -107,7 +107,7 @@ xcopy "$(TargetDir)QModManager.OculusNewtonsoftRedirect.dll" "$(SolutionDir)Vort
 xcopy "$(TargetDir)QModInstaller.dll" "$(SolutionDir)VortexBuild\$(Configuration)\BepInEx\plugins\QModManager\"  /I /Q /Y
 xcopy "$(TargetDir)QModInstaller.xml" "$(SolutionDir)VortexBuild\$(Configuration)\BepInEx\plugins\QModManager\"   /I /Q /Y
 
-powershell Compress-Archive -Path '$(SolutionDir)VortexBuild\$(Configuration)\Bepinex' -DestinationPath '$(SolutionDir)VortexBuild\QModManager_$(Configuration).zip' -Force
+powershell Compress-Archive -Path '$(SolutionDir)VortexBuild\$(Configuration)\BepInEx' -DestinationPath '$(SolutionDir)VortexBuild\QModManager_$(Configuration).zip' -Force
 powershell Compress-Archive -LiteralPath '$(SolutionDir)VortexBuild\$(Configuration)\doorstop_config.ini', '$(SolutionDir)VortexBuild\$(Configuration)\winhttp.dll' -DestinationPath '$(SolutionDir)VortexBuild\QModManager_$(Configuration).zip' -Update
 
 echo F|xcopy /S /Q /Y /F  "$(SolutionDir)Installer\$(Configuration).iss" "$(TargetDir)\QModsInstallerScript.iss"

--- a/QModPluginEmulator/QModPluginGenerator.cs
+++ b/QModPluginEmulator/QModPluginGenerator.cs
@@ -4,6 +4,7 @@ using BepInEx.Logging;
 using HarmonyLib;
 using Mono.Cecil;
 #if SUBNAUTICA_STABLE
+using System.Collections;
 using Oculus.Newtonsoft.Json;
 #else
 using Newtonsoft.Json;
@@ -12,7 +13,6 @@ using QModManager.API;
 using QModManager.Patching;
 using QModManager.Utility;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;

--- a/QModPluginEmulator/QModPluginGenerator.cs
+++ b/QModPluginEmulator/QModPluginGenerator.cs
@@ -19,7 +19,6 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
-using QModManager.API.ModLoading;
 using TypeloaderCache = System.Collections.Generic.Dictionary<string, BepInEx.Bootstrap.CachedAssembly<BepInEx.PluginInfo>>;
 using QMMAssemblyCache = System.Collections.Generic.Dictionary<string, long>;
 
@@ -44,15 +43,13 @@ namespace QModManager
         internal static Dictionary<string, QMod> QModsToLoadById;
         internal static Dictionary<string, PluginInfo> QModPluginInfos;
         internal static List<PluginInfo> InitialisedQModPlugins;
-        private static Initializer Initializer;
-        private static List<QMod> ModsToLoad;
         private static Harmony Harmony;
         internal static IVersionParser VersionParserService { get; set; } = new VersionParser();
 
         private static TypeloaderCache PluginCache;
 
         [Obsolete("Should not be used!", true)]
-        public static void Finish()
+        public static void Initialize()
         {
             try
             {
@@ -74,6 +71,9 @@ namespace QModManager
                     typeof(TypeLoader).GetMethod(nameof(TypeLoader.FindPluginTypes)).MakeGenericMethod(typeof(PluginInfo)),
                     postfix: new HarmonyMethod(typeof(QModPluginGenerator).GetMethod(nameof(TypeLoaderFindPluginTypesPostfix))));
 
+                Harmony.Patch(
+                    typeof(MetadataHelper).GetMethod(nameof(MetadataHelper.GetMetadata), new Type[] { typeof(object) }),
+                        prefix: new HarmonyMethod(AccessTools.Method(typeof(QModPluginGenerator), nameof(QModPluginGenerator.MetadataHelperGetMetadataPrefix))));
             }
             catch (Exception ex)
             {
@@ -102,94 +102,6 @@ namespace QModManager
                 __result = pattern.Replace(__result, string.Empty).Trim();
             }
         }
-
-#if SUBNAUTICA_STABLE
-        [HarmonyPatch(typeof(SystemsSpawner), nameof(SystemsSpawner.Awake))]
-        [HarmonyPrefix]
-        private static void PreInitializeQMM()
-        {
-            Patcher.Patch(); // Run QModManager patch
-
-            ModsToLoad = QModsToLoad.ToList();
-            Initializer = new Initializer(Patcher.CurrentlyRunningGame);
-            Initializer.InitializeMods(ModsToLoad, PatchingOrder.MetaPreInitialize);
-            Initializer.InitializeMods(ModsToLoad, PatchingOrder.PreInitialize);
-            Initializer.InitializeMods(ModsToLoad, PatchingOrder.NormalInitialize);
-            Initializer.InitializeMods(ModsToLoad, PatchingOrder.PostInitialize);
-            Initializer.InitializeMods(ModsToLoad, PatchingOrder.MetaPostInitialize);
-
-            SummaryLogger.ReportIssues(ModsToLoad);
-            SummaryLogger.LogSummaries(ModsToLoad);
-            foreach(Dialog dialog in Patcher.Dialogs)
-            {
-                dialog.Show();
-            }
-
-        }
-#else
-        [HarmonyPatch(typeof(PreStartScreen), nameof(PreStartScreen.Start))]
-        [HarmonyPrefix]
-        private static void PreInitializeQMM()
-        {
-
-
-            Patcher.Patch(); // Run QModManager patch
-
-            ModsToLoad = QModsToLoad.ToList();
-            Initializer = new Initializer(Patcher.CurrentlyRunningGame);
-            Initializer.InitializeMods(ModsToLoad, PatchingOrder.MetaPreInitialize);
-            Initializer.InitializeMods(ModsToLoad, PatchingOrder.PreInitialize);
-
-            Harmony.Patch(
-                AccessTools.Method(
-#if SUBNAUTICA
-                    typeof(PlatformUtils), nameof(PlatformUtils.PlatformInitAsync)
-#elif BELOWZERO
-                    typeof(SpriteManager), nameof(SpriteManager.OnLoadedSpriteAtlases)
-#endif
-                    ), postfix: new HarmonyMethod(AccessTools.Method(typeof(QModPluginGenerator), nameof(QModPluginGenerator.InitializeQMM))));
-        }
-
-#if SUBNAUTICA_EXP
-        private static IEnumerator InitializeQMM(IEnumerator result)
-        {
-            if (ModsToLoad != null)
-            {
-                yield return result;
-
-                Initializer.InitializeMods(ModsToLoad, PatchingOrder.NormalInitialize);
-                Initializer.InitializeMods(ModsToLoad, PatchingOrder.PostInitialize);
-                Initializer.InitializeMods(ModsToLoad, PatchingOrder.MetaPostInitialize);
-
-                SummaryLogger.ReportIssues(ModsToLoad);
-                SummaryLogger.LogSummaries(ModsToLoad);
-                foreach (Dialog dialog in Patcher.Dialogs)
-                {
-                    dialog.Show();
-                }
-            }
-            yield break;
-        }
-#elif BELOWZERO
-        private static void InitializeQMM()
-        {
-            if (ModsToLoad != null)
-            {
-                Initializer.InitializeMods(ModsToLoad, PatchingOrder.NormalInitialize);
-                Initializer.InitializeMods(ModsToLoad, PatchingOrder.PostInitialize);
-                Initializer.InitializeMods(ModsToLoad, PatchingOrder.MetaPostInitialize);
-
-                SummaryLogger.ReportIssues(ModsToLoad);
-                SummaryLogger.LogSummaries(ModsToLoad);
-
-                foreach (Dialog dialog in Patcher.Dialogs)
-                {
-                    dialog.Show();
-                }
-            }
-        }
-#endif
-#endif
 
         private static string[] QMMKnownAssemblyPaths = new[] {
 #if !SUBNAUTICA_STABLE
@@ -328,7 +240,6 @@ namespace QModManager
         [Obsolete("Should not be used!", true)]
         public static void TypeLoaderFindPluginTypesPostfix(ref Dictionary<string, List<PluginInfo>> __result, string directory)
         {
-            Harmony.PatchAll(typeof(QModPluginGenerator));
             if (directory != Paths.PluginPath)
                 return;
 
@@ -418,17 +329,18 @@ namespace QModManager
                 __result[Assembly.GetExecutingAssembly().Location] = QModPluginInfos.Values.Distinct().ToList();
 
                 TypeLoader.SaveAssemblyCache(GeneratedPluginCache, result);
-
             }
             catch (Exception ex)
             {
                 Logger.LogFatal($"Failed to emulate QMods as plugins");
                 Logger.LogFatal(ex.ToString());
             }
+            finally
+            {
+                QModInstaller.QMMLoader.QModsToLoad = QModsToLoad?.ToList();
+            }
         }
 
-        [HarmonyPatch(typeof(MetadataHelper), nameof(MetadataHelper.GetMetadata), new Type[] { typeof(object) })]
-        [HarmonyPrefix]
         private static bool MetadataHelperGetMetadataPrefix(object plugin, ref BepInPlugin __result)
         {
             if (plugin is QModPlugin)


### PR DESCRIPTION
This PR aims to resolve the issue where BepInEx plugins are being destroyed on game launch - it addresses this by distributing a default BepInEx.cfg file that sets the entrypoint for BepInEx plugins to an appropriate starting point, i.e. after the wipe.

Additionally, since the initialization of QMods was moved from QMMLoader into QModPluginGenerator to workaround this issue, I have moved the initialization of QMods back into QMMLoader.

#### [Installer builds](https://github.com/SubnauticaModding/QModManager/files/6581181/Build.zip)

#### Vortex builds
[QModManager_BZ.EXP.zip](https://github.com/SubnauticaModding/QModManager/files/6581176/QModManager_BZ.EXP.zip)
[QModManager_BZ.STABLE.zip](https://github.com/SubnauticaModding/QModManager/files/6581177/QModManager_BZ.STABLE.zip)
[QModManager_SN.EXP.zip](https://github.com/SubnauticaModding/QModManager/files/6581178/QModManager_SN.EXP.zip)
[QModManager_SN.STABLE.zip](https://github.com/SubnauticaModding/QModManager/files/6581179/QModManager_SN.STABLE.zip)