### PR TITLE
Dynamic folder paths.

### DIFF
--- a/QModManager/Patching/Patcher.cs
+++ b/QModManager/Patching/Patcher.cs
@@ -67,12 +67,24 @@ namespace QModManager.Patching
                     Logger.Exception(e);
                 }
 
-                if (!QModBaseDir.StartsWith(Environment.CurrentDirectory))
+                var normalizedModDir = Path.GetFullPath(QModBaseDir);
+                if (!normalizedModDir.EndsWith($"{Path.DirectorySeparatorChar}") && !normalizedModDir.EndsWith($"{Path.AltDirectorySeparatorChar}"))
+                    normalizedModDir += $"{Path.DirectorySeparatorChar}";
+                var ModDirUri = new Uri(normalizedModDir);
+
+                var normalizedGameDir = Path.GetFullPath(Environment.CurrentDirectory);
+                
+                if (!normalizedGameDir.EndsWith($"{Path.DirectorySeparatorChar}") && !normalizedGameDir.EndsWith($"{Path.AltDirectorySeparatorChar}"))
+                    normalizedGameDir += $"{Path.DirectorySeparatorChar}";
+                var GameDirUri = new Uri(normalizedGameDir);
+
+
+                if (!GameDirUri.IsBaseOf(ModDirUri))
                 {
                     try
                     {
                         Logger.Info("Mods Folder structure:");
-                        IOUtilities.LogFolderStructureAsTree(QModBaseDir);
+                        IOUtilities.LogFolderStructureAsTree(Path.Combine(BepInEx.Paths.BepInExRootPath, ".."));
                         Logger.Info("Mods Folder structure ended.");
                     }
                     catch (Exception e)

--- a/QModManager/Patching/Patcher.cs
+++ b/QModManager/Patching/Patcher.cs
@@ -13,7 +13,7 @@ namespace QModManager.Patching
     {
         internal const string IDRegex = "[^0-9a-zA-Z_]";
 
-        internal static string QModBaseDir => Path.Combine(Environment.CurrentDirectory, "QMods");
+        internal static string QModBaseDir => Path.Combine(BepInEx.Paths.BepInExRootPath, "../QMods");
 
         private static bool Patched = false;
         internal static QModGame CurrentlyRunningGame { get; private set; } = QModGame.None;
@@ -54,16 +54,32 @@ namespace QModManager.Patching
                     return;
                 }
 
+
                 try
                 {
-                    Logger.Info("Folder structure:");
+                    Logger.Info("Game Folder structure:");
                     IOUtilities.LogFolderStructureAsTree();
-                    Logger.Info("Folder structure ended.");
+                    Logger.Info("Game Folder structure ended.");
                 }
                 catch (Exception e)
                 {
                     Logger.Error("There was an error while trying to display the folder structure.");
                     Logger.Exception(e);
+                }
+
+                if (!QModBaseDir.StartsWith(Environment.CurrentDirectory))
+                {
+                    try
+                    {
+                        Logger.Info("Mods Folder structure:");
+                        IOUtilities.LogFolderStructureAsTree(QModBaseDir);
+                        Logger.Info("Mods Folder structure ended.");
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.Error("There was an error while trying to display the folder structure.");
+                        Logger.Exception(e);
+                    }
                 }
 
                 PirateCheck.IsPirate(Environment.CurrentDirectory);

--- a/QModPluginEmulator/QModPluginGenerator.cs
+++ b/QModPluginEmulator/QModPluginGenerator.cs
@@ -27,14 +27,10 @@ namespace QModManager
 
     public static class QModPluginGenerator
     {
-        internal static readonly string QModsPath = Path.Combine(Paths.GameRootPath, "QMods");
-        private static readonly string BepInExRootPath = Path.Combine(Paths.GameRootPath, "BepInEx");
-        private static readonly string BepInExCachePath = Path.Combine(Paths.BepInExRootPath, "cache");
-        private static readonly string BepInExPatchersPath = Path.Combine(Paths.BepInExRootPath, "patchers");
-        private static readonly string BepInExPluginsPath = Path.Combine(Paths.BepInExRootPath, "plugins");
-        private static readonly string QMMPatchersPath = Path.Combine(BepInExPatchersPath, "QModManager");
-        private static readonly string QMMPluginsPath = Path.Combine(BepInExPluginsPath, "QModManager");
-        private static readonly string QMMAssemblyCachePath = Path.Combine(BepInExCachePath, "qmodmanager.dat");
+        internal static readonly string QModsPath = Path.Combine(Paths.BepInExRootPath, "../QMods");
+        private static readonly string QMMPatchersPath = Path.Combine(Paths.PatcherPluginPath, "QModManager");
+        private static readonly string QMMPluginsPath = Path.Combine(Paths.PluginPath, "QModManager");
+        private static readonly string QMMAssemblyCachePath = Path.Combine(Paths.CachePath, "qmodmanager.dat");
         private static QMMAssemblyCache QMMAssemblyCache;
 
         private static readonly ManualLogSource Logger = BepInEx.Logging.Logger.CreateLogSource("QModPluginGenerator");
@@ -141,7 +137,7 @@ namespace QModManager
 
             try
             {
-                Directory.CreateDirectory(BepInExCachePath);
+                Directory.CreateDirectory(Paths.CachePath);
 
                 using (var ms = new MemoryStream())
                 using (var writer = new StreamWriter(ms))
@@ -164,7 +160,7 @@ namespace QModManager
 
         private static void ClearBepInExCache()
         {
-            if (!Directory.Exists(BepInExCachePath))
+            if (!Directory.Exists(Paths.CachePath))
                 return;
 
             Logger.LogInfo("Clearing BepInEx cache...");
@@ -172,7 +168,7 @@ namespace QModManager
 
             try
             {
-                Directory.Delete(BepInExCachePath, true);
+                Directory.Delete(Paths.CachePath, true);
             }
             catch (IOException e)
             {

--- a/UnityAudioFixer/UnityAudioFixer.cs
+++ b/UnityAudioFixer/UnityAudioFixer.cs
@@ -17,8 +17,7 @@ namespace QModManager
     public static class UnityAudioFixer
     {
         internal static string UnityAudioFixerPath => Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-        internal static string GameRootPath => Environment.CurrentDirectory;
-        internal static string DataPath => Directory.GetDirectories(GameRootPath, "*_Data", SearchOption.TopDirectoryOnly).SingleOrDefault();
+        internal static string DataPath => Directory.GetDirectories(Paths.GameRootPath, "*_Data", SearchOption.TopDirectoryOnly).SingleOrDefault();
         internal static QModGame Game
         {
             get

--- a/UnityAudioFixer/UnityAudioFixer.cs
+++ b/UnityAudioFixer/UnityAudioFixer.cs
@@ -17,7 +17,7 @@ namespace QModManager
     public static class UnityAudioFixer
     {
         internal static string UnityAudioFixerPath => Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-        internal static string GameRootPath => Path.Combine(UnityAudioFixerPath, "../../..");
+        internal static string GameRootPath => Environment.CurrentDirectory;
         internal static string DataPath => Directory.GetDirectories(GameRootPath, "*_Data", SearchOption.TopDirectoryOnly).SingleOrDefault();
         internal static QModGame Game
         {

--- a/UnityAudioFixer/UnityAudioFixer.cs
+++ b/UnityAudioFixer/UnityAudioFixer.cs
@@ -1,5 +1,6 @@
 ﻿using AssetsTools.NET;
 using AssetsTools.NET.Extra;
+using BepInEx;
 using BepInEx.Logging;
 using Mono.Cecil;
 using QModManager.API;


### PR DESCRIPTION
Allows Bepinex folder and Qmods folder to be installed in locations other then the game dir so that you can just point the doorstop config to the install path and load mods from anywhere.
 
 
Mostly this is needed for possible upcoming mod managers to have mods loaded from different profiles and a few other possibilities.

