### PR TITLE
Error logs for invalid JSON in mod.json

### DIFF
--- a/QModManager/Patching/ManifestValidator.cs
+++ b/QModManager/Patching/ManifestValidator.cs
@@ -35,7 +35,7 @@
                 string.IsNullOrEmpty(mod.DisplayName) ||
                 string.IsNullOrEmpty(mod.Author))
             {
-                mod.Status = ModStatus.MissingCoreInfo;
+                mod.Status = ModStatus.InvalidCoreInfo;
                 return;
             }
 

--- a/QModManager/Patching/ModStatus.cs
+++ b/QModManager/Patching/ModStatus.cs
@@ -18,11 +18,12 @@
         FailedIdentifyingGame = 9,
         DuplicateIdDetected = 10,
         DuplicatePatchAttemptDetected = 11,
-        MissingCoreInfo = 12,
-        InvalidCoreInfo = 13,
-        MissingAssemblyFile = 14,
-        FailedLoadingAssemblyFile = 15,
-        UnidentifiedMod = 16,
-        BannedID = 17,
+        MissingManifest = 12,
+        ManifestParsingError = 13,
+        InvalidCoreInfo = 14,
+        MissingAssemblyFile = 15,
+        FailedLoadingAssemblyFile = 16,
+        UnidentifiedMod = 17,
+        BannedID = 18,
     }
 }

--- a/QModManager/Patching/QModFactory.cs
+++ b/QModManager/Patching/QModFactory.cs
@@ -68,8 +68,8 @@
 
                 if (!File.Exists(jsonFile))
                 {
-                    Logger.Error($"Unable to set up mod in folder \"{folderName}\"");
-                    earlyErrors.Add(new QModPlaceholder(folderName, ModStatus.MissingCoreInfo));
+                    Logger.Error($"Unable to set up mod in folder \"{folderName}\" due to missing mod.json");
+                    earlyErrors.Add(new QModPlaceholder(folderName, ModStatus.MissingManifest));
                     continue;
                 }
 
@@ -77,8 +77,8 @@
 
                 if (mod == null)
                 {
-                    Logger.Error($"Unable to set up mod in folder \"{folderName}\"");
-                    earlyErrors.Add(new QModPlaceholder(folderName, ModStatus.MissingCoreInfo));
+                    Logger.Error($"Unable to set up mod in folder \"{folderName}\" due to invalid json in the mod.json");
+                    earlyErrors.Add(new QModPlaceholder(folderName, ModStatus.ManifestParsingError));
                     continue;
                 }
 

--- a/QModManager/Utility/SummaryLogger.cs
+++ b/QModManager/Utility/SummaryLogger.cs
@@ -25,8 +25,9 @@
             LogStatus(mods, ModStatus.FailedIdentifyingGame, "Could not identify the supported game for the following mods:", Logger.Level.Error);
             LogStatus(mods, ModStatus.DuplicateIdDetected, "Found the following duplicate mods:", Logger.Level.Error);
             LogStatus(mods, ModStatus.DuplicatePatchAttemptDetected, "Found the following mods attempted duplicate patching:", Logger.Level.Error);
-            LogStatus(mods, ModStatus.MissingCoreInfo, "The following mods could not be loaded for patching due to a missing mod.json file:", Logger.Level.Error);
-            LogStatus(mods, ModStatus.InvalidCoreInfo, "The following mods could not be loaded for patching due to an invalid mod.json file:", Logger.Level.Error);
+            LogStatus(mods, ModStatus.MissingManifest, "The following mods could not be loaded for patching due to a missing mod.json file:", Logger.Level.Error);
+            LogStatus(mods, ModStatus.ManifestParsingError, "The following mods could not be loaded for patching due to an unreadable mod.json file:", Logger.Level.Error);
+            LogStatus(mods, ModStatus.InvalidCoreInfo, "The following mods could not be loaded for patching due to missing or invalid data in the mod.json file:", Logger.Level.Error);
             LogStatus(mods, ModStatus.MissingAssemblyFile, "The following mods had no DLL file to load:", Logger.Level.Error);
             LogStatus(mods, ModStatus.FailedLoadingAssemblyFile, "The following mods failing loading their DLL files:", Logger.Level.Error);
             LogStatus(mods, ModStatus.UnidentifiedMod, "The following mods could not be identified for loading:", Logger.Level.Error);


### PR DESCRIPTION
- Better error logs when the mod.json file contains invalid JSON
  - Adds a new ModStatus `ManifestParsingError`
  - Renamed the ModStatus `MissingCoreInfo` to `MissingManifest` for clarity
  - Updated relevant logs