### PR TITLE
Improved piracy check to reduce false positives.

### DIFF
--- a/QModManager/Checks/PirateCheck.cs
+++ b/QModManager/Checks/PirateCheck.cs
@@ -6,12 +6,14 @@ namespace QModManager.Checks
 {
     internal static class PirateCheck
     {
-        internal static void PirateDetected()
+        private const int FileSize = 220000;
+      
+        private static void PirateDetected()
         {
             Logger.Warn("Ahoy, matey! Ye be a pirate!");
         }
-
-        internal static readonly HashSet<string> CrackedFiles = new HashSet<string>()
+        
+        private static readonly HashSet<string> CrackedFiles = new HashSet<string>()
         {
             "steam_api64.cdx",
             "steam_api64.ini",
@@ -29,20 +31,20 @@ namespace QModManager.Checks
 
         internal static void IsPirate(string folder)
         {
-            string steamDll = Path.Combine(folder, "steam_api64.dll");
+            var steamDll = Path.Combine(folder, "steam_api64.dll");
             if (File.Exists(steamDll))
             {
-                FileInfo fileInfo = new FileInfo(steamDll);
-
-                if (fileInfo.Length > 220000)
+                FileInfo dllInfo = new FileInfo(steamDll);
+                if (dllInfo.Length > FileSize)
                 {
-                    PirateDetected();
-                    return;
+                    FileChecking(folder);
                 }
             }
-
-            foreach (string file in CrackedFiles)
-            {
+        }
+        
+        private static void FileChecking(string folder)
+        {
+            foreach (var file in CrackedFiles) {
                 if (File.Exists(Path.Combine(folder, file)))
                 {
                     PirateDetected();


### PR DESCRIPTION
The title says everything, really.
Changes:
Moved the file size of steam_api64.dll to a const so it can be easily updated in the future.

Changed the way the initial check was done. Before, it checked the size of steam_api64.dll *and* checked for files related to pirated versions. Replace the "and" with "then", and that's what the change is. This was done to reduce false positives, as there is the possibility someone pirates the game, then later buys it, installs to the same folder, which would leave those files behind, resulting in a false positive. 

Renamed internal things to private because rider was giving me yellow squiggles and they bothered me.

Changed a datatype or two to "var" for the same reason as above.

No other changes were done, as it still has the same behavior as before. If the check succeeds, it logs it and moves on with loading, provided no other additional errors were encountered.