### PR TITLE
Allow mods to check what game is currently running.

### DIFF
--- a/QModManager/API/QModServices.cs
+++ b/QModManager/API/QModServices.cs
@@ -138,5 +138,13 @@
             var callingMod = GetMod(ReflectionHelper.CallingAssemblyByStackTrace());
             MainMenuMessages.Add(msg, callingMod?.DisplayName, size, color, autoformat);
         }
+
+        /// <summary>
+        /// Gets the currently running game.
+        /// </summary>
+        /// <value>
+        /// The currently running game.
+        /// </value>
+        public QModGame CurrentlyRunningGame => Patcher.CurrentlyRunningGame;
     }
 }


### PR DESCRIPTION
I noticed that it isn't currently possible for mods to do this without some hacky workarounds.