### PR TITLE
Fix Nitrox dependency errors

### DIFF
--- a/QModManager/Checks/NitroxCheck.cs
+++ b/QModManager/Checks/NitroxCheck.cs
@@ -1,35 +1,9 @@
-﻿using HarmonyLib;
-using System.Collections.Generic;
-using System.Reflection;
-using System.Reflection.Emit;
+﻿using System;
 
 namespace QModManager.Checks
 {
     internal static class NitroxCheck
     {
-        internal static bool IsRunning { get; set; } = false;
-
-        
-        [HarmonyPatch(typeof(GameInput), nameof(GameInput.Awake))]
-        internal static class AwakePatch
-        {
-            internal static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
-            {
-                foreach (CodeInstruction instruction in instructions)
-                {
-                    if (instruction.opcode == OpCodes.Call)
-                    {
-                        MethodInfo method = (MethodInfo)instruction.operand;
-
-                        if (method.DeclaringType.Name == "Main" && method.Name == "Execute")
-                        {
-                            IsRunning = true;
-                        }
-                    }
-                }
-
-                return instructions;
-            }
-        }
+        internal static bool IsRunning => Environment.GetEnvironmentVariable("NITROX_LAUNCHER_PATH") is not null;
     }
 }

--- a/QModManager/Patching/Initializer.cs
+++ b/QModManager/Patching/Initializer.cs
@@ -1,6 +1,4 @@
-﻿using QModManager.Checks;
-
-namespace QModManager.API.ModLoading
+﻿namespace QModManager.API.ModLoading
 {
     using QModManager.Patching;
     using QModManager.Utility;
@@ -29,14 +27,6 @@ namespace QModManager.API.ModLoading
                 {
                     mod.PatchMethods.Clear(); // Do not attempt any other patch methods
                     mod.Status = ModStatus.CurrentGameNotSupported;
-                    continue;
-                }
-
-                
-                if(!mod.NitroxCompat && NitroxCheck.IsRunning)
-                {
-                    mod.PatchMethods.Clear(); // Do not attempt any other patch methods
-                    mod.Status = ModStatus.NitroxIncompatible;
                     continue;
                 }
 

--- a/QModManager/Patching/ManifestValidator.cs
+++ b/QModManager/Patching/ManifestValidator.cs
@@ -2,6 +2,7 @@
 {
     using QModManager.API;
     using QModManager.API.ModLoading;
+    using QModManager.Checks;
     using QModManager.Utility;
     using System;
     using System.Collections.Generic;
@@ -63,10 +64,14 @@
                     mod.SupportedGame = QModGame.Subnautica;
                     break;
                 default:
-                {
                     mod.Status = ModStatus.FailedIdentifyingGame;
                     return;
-                }
+            }
+
+            if (!mod.NitroxCompat && NitroxCheck.IsRunning)
+            {
+                mod.Status = ModStatus.NitroxIncompatible;
+                return;
             }
 
             try
@@ -241,7 +246,7 @@
             }
             catch (ReflectionTypeLoadException rtle)
             {
-                Logger.Debug($"Unable to load types for '{qMod.Id}': \nInnerException: \n" + rtle.InnerException + "\n LoaderExceptions:\n" +string.Join("/n", rtle.LoaderExceptions.ToList()));
+                Logger.Debug($"Unable to load types for '{qMod.Id}': \nInnerException: \n" + rtle.InnerException + "\n LoaderExceptions:\n" + string.Join("/n", rtle.LoaderExceptions.ToList()));
                 qMod.Status = ModStatus.MissingDependency;
             }
 

--- a/QModManager/Utility/SummaryLogger.cs
+++ b/QModManager/Utility/SummaryLogger.cs
@@ -50,22 +50,20 @@
                 switch (statusToReport)
                 {
                     case ModStatus.MissingDependency:
+                        if (mod.HasDependencies)
                         {
-                            if (mod.HasDependencies)
+                            Console.WriteLine($"- {mod.DisplayName} ({mod.Id}) is missing these dependencies:");
+                            foreach (RequiredQMod dependency in mod.RequiredMods)
                             {
-                                Console.WriteLine($"- {mod.DisplayName} ({mod.Id}) is missing these dependencies:");
-                                foreach (RequiredQMod dependency in mod.RequiredMods)
-                                {
-                                    if (QModServices.Main.GetMod(mod.Id) is not IQMod requiredMod || !requiredMod.IsLoaded || !requiredMod.Enable)
-                                        Console.WriteLine($"   - {dependency.Id}{(dependency.RequiresMinimumVersion ? $" at version {dependency.MinimumVersion} or newer" : string.Empty)}");
-                                }
+                                if (QModServices.Main.GetMod(mod.Id) is not IQMod requiredMod || !requiredMod.IsLoaded || !requiredMod.Enable)
+                                    Console.WriteLine($"   - {dependency.Id}{(dependency.RequiresMinimumVersion ? $" at version {dependency.MinimumVersion} or newer" : string.Empty)}");
                             }
-                            else
-                            {
-                                Console.WriteLine($"- {mod.DisplayName} ({mod.Id}) is missing a dependency but none are listed in mod.json, Please check Nexusmods for list of Dependencies.");
-                            }
-                            break;
                         }
+                        else
+                        {
+                            Console.WriteLine($"- {mod.DisplayName} ({mod.Id}) is missing a dependency but none are listed in mod.json, Please check Nexusmods for list of Dependencies.");
+                        }
+                        break;
 
                     case ModStatus.OutOfDateDependency:
                         Console.WriteLine($"- {mod.DisplayName} ({mod.Id}) requires a newer version of these dependencies:");

--- a/QModManager/Utility/SummaryLogger.cs
+++ b/QModManager/Utility/SummaryLogger.cs
@@ -50,22 +50,22 @@
                 switch (statusToReport)
                 {
                     case ModStatus.MissingDependency:
-                    {
-                        if (mod.HasDependencies)
                         {
-                            Console.WriteLine($"- {mod.DisplayName} ({mod.Id}) is missing these dependencies:");
-                            foreach (RequiredQMod dependency in mod.RequiredMods)
+                            if (mod.HasDependencies)
                             {
-                                if (!QModServices.Main.ModPresent(dependency.Id))
-                                    Console.WriteLine($"   - {dependency.Id}{(dependency.RequiresMinimumVersion ? $" at version {dependency.MinimumVersion} or newer" : string.Empty)}");
+                                Console.WriteLine($"- {mod.DisplayName} ({mod.Id}) is missing these dependencies:");
+                                foreach (RequiredQMod dependency in mod.RequiredMods)
+                                {
+                                    if (QModServices.Main.GetMod(mod.Id) is not IQMod requiredMod || !requiredMod.IsLoaded || !requiredMod.Enable)
+                                        Console.WriteLine($"   - {dependency.Id}{(dependency.RequiresMinimumVersion ? $" at version {dependency.MinimumVersion} or newer" : string.Empty)}");
+                                }
                             }
+                            else
+                            {
+                                Console.WriteLine($"- {mod.DisplayName} ({mod.Id}) is missing a dependency but none are listed in mod.json, Please check Nexusmods for list of Dependencies.");
+                            }
+                            break;
                         }
-                        else
-                        {
-                            Console.WriteLine($"- {mod.DisplayName} ({mod.Id}) is missing a dependency but none are listed in mod.json, Please check Nexusmods for list of Dependencies.");
-                        }
-                        break;
-                    }
 
                     case ModStatus.OutOfDateDependency:
                         Console.WriteLine($"- {mod.DisplayName} ({mod.Id}) requires a newer version of these dependencies:");
@@ -75,8 +75,8 @@
                             {
                                 IQMod dependencyDetails = QModServices.Main.FindModById(dependency.Id);
 
-                                if (dependencyDetails == null || dependencyDetails.ParsedVersion < dependency.MinimumVersion)                                
-                                    Console.WriteLine($"   - {dependency.Id} at version {dependency.MinimumVersion} or newer");                                
+                                if (dependencyDetails == null || dependencyDetails.ParsedVersion < dependency.MinimumVersion)
+                                    Console.WriteLine($"   - {dependency.Id} at version {dependency.MinimumVersion} or newer");
                             }
                         }
                         break;


### PR DESCRIPTION
Fixes an issue with Nitrox compatibility where mods that are marked as Nitrox compatible will be loaded even if they depend on mods which are _not_ Nitrox compatible, leading to glitchy behaviour.