### PR TITLE
Unify sn1.exp/bz installs

### DIFF
--- a/QModManager/BepInex/Plugins/QMMLoader.cs
+++ b/QModManager/BepInex/Plugins/QMMLoader.cs
@@ -84,15 +84,14 @@ namespace QModInstaller.BepInEx.Plugins
         {
             while (result.MoveNext())
             {
-                yield return result;
+                yield return result.Current;
             }
 
-            var hasInitializedField = typeof(SpriteManager).GetField("hasInitialized", System.Reflection.BindingFlags.Static);
+            var hasInitializedField = typeof(SpriteManager).GetField("hasInitialized", System.Reflection.BindingFlags.Public|System.Reflection.BindingFlags.Static);
             if (hasInitializedField != null)
             {
-                bool hasInitialized = (bool)hasInitializedField.GetValue(null);
-                if (!hasInitialized)
-                    yield return new WaitUntil(() => hasInitialized);
+                if (!(bool)hasInitializedField.GetValue(null))
+                    yield return new WaitUntil(() => (bool)hasInitializedField.GetValue(null));
             }
 
             Initializer.InitializeMods(QModsToLoad, PatchingOrder.NormalInitialize);

--- a/QModManager/BepInex/Plugins/QMMLoader.cs
+++ b/QModManager/BepInex/Plugins/QMMLoader.cs
@@ -87,10 +87,13 @@ namespace QModInstaller.BepInEx.Plugins
                 yield return result;
             }
 
-#if BELOWZERO
-            if(!SpriteManager.hasInitialized)
-                yield return new WaitUntil(()=>SpriteManager.hasInitialized);
-#endif
+            var hasInitializedField = typeof(SpriteManager).GetField("hasInitialized", System.Reflection.BindingFlags.Static);
+            if (hasInitializedField != null)
+            {
+                bool hasInitialized = (bool)hasInitializedField.GetValue(null);
+                if (!hasInitialized)
+                    yield return new WaitUntil(() => hasInitialized);
+            }
 
             Initializer.InitializeMods(QModsToLoad, PatchingOrder.NormalInitialize);
             Initializer.InitializeMods(QModsToLoad, PatchingOrder.PostInitialize);

--- a/QModManager/HarmonyPatches/EnableConsoleSetting.cs
+++ b/QModManager/HarmonyPatches/EnableConsoleSetting.cs
@@ -12,13 +12,13 @@
         [HarmonyPostfix]
         internal static void Postfix()
         {
-#if BELOWZERO || SUBNAUTICA_EXP
+#if !SUBNAUTICA_STABLE
             if (PlatformUtils.GetDevToolsEnabled() != Config.EnableConsole)
 #else
             if (DevConsole.disableConsole != !Config.EnableConsole)
 #endif
             {
-#if BELOWZERO || SUBNAUTICA_EXP
+#if !SUBNAUTICA_STABLE
                 PlatformUtils.SetDevToolsEnabled(Config.EnableConsole);
 #else
                 DevConsole.disableConsole = !Config.EnableConsole;

--- a/QModManager/OptionsManager.cs
+++ b/QModManager/OptionsManager.cs
@@ -17,6 +17,7 @@
                 ModsTab = __instance.AddTab("Mods");
                 __instance.AddHeading(ModsTab, "QModManager");
 
+                //TODO: This is the Last berrier to unifying the 2 games installs.....  Below Zero has an optional value at the end of AddToggleOption that makes it so these fail when using a binary compiled on the wrong game.
                 __instance.AddToggleOption(ModsTab, "Check for updates", Config.CheckForUpdates, new UnityAction<bool>(value => Config.CheckForUpdates = value));
 
                 __instance.AddToggleOption(ModsTab, "Enable console", Config.EnableConsole, new UnityAction<bool>(value =>

--- a/QModManager/OptionsManager.cs
+++ b/QModManager/OptionsManager.cs
@@ -1,7 +1,10 @@
 ﻿namespace QModManager
 {
     using HarmonyLib;
+    using QModManager.API;
+    using QModManager.Patching;
     using QModManager.Utility;
+    using System.Reflection;
     using UnityEngine.Events;
 
     internal static class OptionsManager
@@ -17,10 +20,14 @@
                 ModsTab = __instance.AddTab("Mods");
                 __instance.AddHeading(ModsTab, "QModManager");
 
-                //TODO: This is the Last berrier to unifying the 2 games installs.....  Below Zero has an optional value at the end of AddToggleOption that makes it so these fail when using a binary compiled on the wrong game.
-                __instance.AddToggleOption(ModsTab, "Check for updates", Config.CheckForUpdates, new UnityAction<bool>(value => Config.CheckForUpdates = value));
+                
+                MethodInfo AddToggleOption = null; 
+                if(Patcher.CurrentlyRunningGame == QModGame.Subnautica)
+                {
+                    AddToggleOption = typeof(uGUI_OptionsPanel).GetMethod(nameof(AddToggleOption), new System.Type[] { typeof(int), typeof(string), typeof(bool), typeof(UnityAction<bool>) });
+                    AddToggleOption.Invoke(__instance, new object[] { ModsTab, "Check for updates", Config.CheckForUpdates, new UnityAction<bool>(value => Config.CheckForUpdates = value) });
 
-                __instance.AddToggleOption(ModsTab, "Enable console", Config.EnableConsole, new UnityAction<bool>(value =>
+                    AddToggleOption.Invoke(__instance, new object[] { ModsTab, "Enable console", Config.EnableConsole, new UnityAction<bool>(value =>
                 {
                     Config.EnableConsole = value;
 #if SUBNAUTICA_STABLE
@@ -29,11 +36,31 @@
 #elif BELOWZERO || SUBNAUTICA_EXP
                     PlatformUtils.SetDevToolsEnabled(value);
 #endif
-                }));
+                }) });
 
-                __instance.AddToggleOption(ModsTab, "Enable debug logs", Config.EnableDebugLogs, new UnityAction<bool>(value => Config.EnableDebugLogs = value));
+                    AddToggleOption.Invoke(__instance, new object[] { ModsTab, "Enable debug logs", Config.EnableDebugLogs, new UnityAction<bool>(value => Config.EnableDebugLogs = value) });
+                    AddToggleOption.Invoke(__instance, new object[] { ModsTab, "Enable developer mode", Config.EnableDevMode, new UnityAction<bool>(value => Config.EnableDevMode = value) });
+                }
+                else
+                {
+                    AddToggleOption = typeof(uGUI_OptionsPanel).GetMethod(nameof(AddToggleOption), new System.Type[] { typeof(int), typeof(string), typeof(bool), typeof(UnityAction<bool>), typeof(string) });
+                    AddToggleOption.Invoke(__instance, new object[] { ModsTab, "Check for updates", Config.CheckForUpdates, new UnityAction<bool>(value => Config.CheckForUpdates = value), null });
 
-                __instance.AddToggleOption(ModsTab, "Enable developer mode", Config.EnableDevMode, new UnityAction<bool>(value => Config.EnableDevMode = value));
+                    AddToggleOption.Invoke(__instance, new object[] { ModsTab, "Enable console", Config.EnableConsole, new UnityAction<bool>(value =>
+                {
+                    Config.EnableConsole = value;
+#if SUBNAUTICA_STABLE
+                    DevConsole.disableConsole = !value;
+                    UnityEngine.PlayerPrefs.SetInt("UWE.DisableConsole", value ? 0 : 1);
+#elif BELOWZERO || SUBNAUTICA_EXP
+                    PlatformUtils.SetDevToolsEnabled(value);
+#endif
+                }), null });
+
+                    AddToggleOption.Invoke(__instance, new object[] { ModsTab, "Enable debug logs", Config.EnableDebugLogs, new UnityAction<bool>(value => Config.EnableDebugLogs = value), null });
+                    AddToggleOption.Invoke(__instance, new object[] { ModsTab, "Enable developer mode", Config.EnableDevMode, new UnityAction<bool>(value => Config.EnableDevMode = value), null });
+                }
+
             }
         }
     }

--- a/QModManager/Patching/GameDetector.cs
+++ b/QModManager/Patching/GameDetector.cs
@@ -20,12 +20,9 @@
         {
 #if SUBNAUTICA_STABLE
             { QModGame.Subnautica, 65786 }
-#elif BELOWZERO_STABLE
-            { QModGame.BelowZero, 45391 }
-#elif SUBNAUTICA_EXP
+#else
+            { QModGame.BelowZero, 45391 },
             { QModGame.Subnautica, 68186 }
-#elif BELOWZERO_EXP
-            { QModGame.BelowZero, 45500 }
 #endif
         };
 

--- a/QModManager/Utility/MainMenuMessages.cs
+++ b/QModManager/Utility/MainMenuMessages.cs
@@ -114,9 +114,9 @@
                 yield return new WaitForSeconds(1f);
 
                 yield return new WaitWhile(() => SaveLoadManager.main.isLoading);
-#if SUBNAUTICA
+#if SUBNAUTICA_STABLE
                 float time = Time.time;
-#elif BELOWZERO
+#else
                 float time = PDA.time;
 #endif
                 messages.ForEach(msg => msg.timeEnd = time + 1f);

--- a/QModPluginEmulator/QModPluginGenerator.cs
+++ b/QModPluginEmulator/QModPluginGenerator.cs
@@ -74,8 +74,6 @@ namespace QModManager
             Path.Combine(QMMPatchersPath, "QModManager.OculusNewtonsoftRedirect.dll"),
 #endif
             Path.Combine(QMMPatchersPath, "QModManager.QModPluginGenerator.dll"),
-            Path.Combine(QMMPatchersPath, "QModManager.UnityAudioFixer.dll"),
-            Path.Combine(QMMPatchersPath, "QModManager.exe"),
             Path.Combine(QMMPluginsPath, "QModInstaller.dll"),
         };
 


### PR DESCRIPTION
remove audio fixer from check as it is now its own plugin and this check always fails on thunderstore install
PDA.time now exists on SN1.EXP allowing unification of time check. 
match other #if statements in repo 
Rewrite SpriteManager initialize check to not need preprocessor