### PR TITLE
Adding Store Detection for Logging

### DIFF
--- a/QModManager/API/IQModServices.cs
+++ b/QModManager/API/IQModServices.cs
@@ -47,5 +47,14 @@
         ///   <c>true</c> if Nitrox is being used; otherwise, <c>false</c>.
         /// </value>
         bool NitroxRunning { get; }
+
+
+        /// <summary>
+        /// Gets a value indicating whether Piracy was detected.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if Piracy was detected; otherwise, <c>false</c>.
+        /// </value>
+        bool PirateDetected { get; }
     }
 }

--- a/QModManager/API/QModServices.cs
+++ b/QModManager/API/QModServices.cs
@@ -157,5 +157,13 @@ namespace QModManager.API
         ///   <c>true</c> if Nitrox is being used; otherwise, <c>false</c>.
         /// </value>
         public bool NitroxRunning => NitroxCheck.IsRunning;
+
+        /// <summary>
+        /// Gets a value indicating whether Piracy was detected.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if Piracy was detected; otherwise, <c>false</c>.
+        /// </value>
+        public bool PirateDetected => PirateCheck.PirateDetected;
     }
 }

--- a/QModManager/BepInex/Plugins/QMMLoader.cs
+++ b/QModManager/BepInex/Plugins/QMMLoader.cs
@@ -9,8 +9,10 @@ using UnityEngine;
 namespace QModInstaller.BepInEx.Plugins
 {
     using QModManager.API.ModLoading;
+    using QModManager.Checks;
     using QModManager.Patching;
     using QModManager.Utility;
+    using System;
 
     /// <summary>
     /// QMMLoader - simply fires up the QModManager entry point.
@@ -25,6 +27,15 @@ namespace QModInstaller.BepInEx.Plugins
 
         internal static List<QMod> QModsToLoad;
         private static Initializer Initializer;
+
+        /// <summary>
+        /// "Only for use by Bepinex"
+        /// </summary>
+        [Obsolete("Only for use by Bepinex", true)]
+        public QMMLoader()
+        {
+            PirateCheck.IsPirate();
+        }
 
         /// <summary>
         /// Prevents a default instance of the <see cref="QMMLoader"/> class from being created 

--- a/QModManager/Checks/PirateCheck.cs
+++ b/QModManager/Checks/PirateCheck.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using Logger = QModManager.Utility.Logger;
 
@@ -10,10 +11,8 @@ namespace QModManager.Checks
         internal static int Steamapilengh => 220000;
 
 
-        internal static void PirateDetected()
-        {
-            Logger.Warn("Ahoy, matey! Ye be a pirate!");
-        }
+        internal static string folder = Environment.CurrentDirectory;
+        internal static bool PirateDetected;
 
         internal static readonly HashSet<string> CrackedFiles = new HashSet<string>()
         {
@@ -31,28 +30,32 @@ namespace QModManager.Checks
             "chuj.cdx",
         };
 
-        internal static void IsPirate(string folder)
+        internal static void IsPirate()
         {
             string steamDll = Path.Combine(folder, Steamapi);
-            if (File.Exists(steamDll))
+            bool steamStore = File.Exists(steamDll);
+            if (steamStore)
             {
                 FileInfo fileInfo = new FileInfo(steamDll);
-
                 if (fileInfo.Length > Steamapilengh)
                 {
-                    PirateDetected();
-                    return;
+                    PirateDetected = true;
                 }
             }
 
-            foreach (string file in CrackedFiles)
+            if (!PirateDetected)
             {
-                if (File.Exists(Path.Combine(folder, file)))
+                foreach (string file in CrackedFiles)
                 {
-                    PirateDetected();
-                    return;
+                    if (File.Exists(Path.Combine(folder, file)))
+                    {
+                        PirateDetected = true;
+                        break;
+                    }
                 }
             }
+
+            Logger.Info(PirateDetected? "Ahoy, matey! Ye be a pirate!":"Seems Legit.");
         }
     }
 }

--- a/QModManager/Checks/PirateCheck.cs
+++ b/QModManager/Checks/PirateCheck.cs
@@ -6,6 +6,10 @@ namespace QModManager.Checks
 {
     internal static class PirateCheck
     {
+        internal static string Steamapi => "steam_api64.dll";
+        internal static int Steamapilengh => 220000;
+
+
         internal static void PirateDetected()
         {
             Logger.Warn("Ahoy, matey! Ye be a pirate!");
@@ -29,12 +33,12 @@ namespace QModManager.Checks
 
         internal static void IsPirate(string folder)
         {
-            string steamDll = Path.Combine(folder, "steam_api64.dll");
+            string steamDll = Path.Combine(folder, Steamapi);
             if (File.Exists(steamDll))
             {
                 FileInfo fileInfo = new FileInfo(steamDll);
 
-                if (fileInfo.Length > 220000)
+                if (fileInfo.Length > Steamapilengh)
                 {
                     PirateDetected();
                     return;

--- a/QModManager/Patching/GameDetector.cs
+++ b/QModManager/Patching/GameDetector.cs
@@ -63,7 +63,7 @@
 
             CurrentGameVersion = SNUtils.GetPlasticChangeSetOfBuild(-1);
 
-            Logger.Info($"Game Version: {CurrentGameVersion} Build Date: {SNUtils.GetDateTimeOfBuild():dd-MMMM-yyyy}");
+            Logger.Info($"Game Version: {CurrentGameVersion} Build Date: {SNUtils.GetDateTimeOfBuild():dd-MMMM-yyyy} Store: {StoreDetector.GetUsedGameStore()}");
             Logger.Info($"Loading QModManager v{Assembly.GetExecutingAssembly().GetName().Version.ToStringParsed()}{(IsValidGameRunning && MinimumBuildVersion != 0 ? $" built for {CurrentlyRunningGame} v{MinimumBuildVersion}" : string.Empty)}...");
             Logger.Info($"Today is {DateTime.Now:dd-MMMM-yyyy_HH:mm:ss}");
 

--- a/QModManager/Patching/Patcher.cs
+++ b/QModManager/Patching/Patcher.cs
@@ -94,8 +94,6 @@ namespace QModManager.Patching
                     }
                 }
 
-                PirateCheck.IsPirate(Environment.CurrentDirectory);
-
                 PatchHarmony();
 
                 if (NitroxCheck.IsRunning)
@@ -112,6 +110,20 @@ namespace QModManager.Patching
 
                     return;
                 }
+
+                /*
+                if (PirateCheck.PirateDetected)
+                {
+                    Dialogs.Add(new Dialog()
+                    {
+                        message = "Ahoy,matey! Ye be a pirate!",
+                        leftButton = Dialog.Button.Pirate,
+                        rightButton = Dialog.Button.Pirate,
+                        color = Dialog.DialogColor.Red,
+                    });
+
+                    return;
+                }*/
 
                 VersionCheck.Check();
 

--- a/QModManager/Patching/StoreDetector.cs
+++ b/QModManager/Patching/StoreDetector.cs
@@ -1,0 +1,114 @@
+﻿namespace QModManager.Patching
+{
+    using System;
+    using System.IO;
+    using Checks;
+
+    internal class StoreDetector
+    {
+        internal static string GetUsedGameStore()
+        {
+            string directory = null;
+
+            try
+            {
+                directory ??= Environment.CurrentDirectory;
+            }
+            catch
+            {
+                return "Error on getting Store";
+            }
+
+            if (NonValidStore(directory))
+            {
+                return "free Store";
+            }
+            else if (IsSteam(directory))
+            {
+                return "Steam";
+            }
+            else if (IsEpic(directory))
+            {
+                return "Eic Games";
+            }
+            else if (IsMSStore(directory))
+            {
+                return "MSStore";
+            }
+            else
+            {
+                return "was not able to identify Store";
+            }
+        }
+
+        internal static bool IsSteam(string directory)
+        {
+            string[] files = Directory.GetFiles(directory);
+            for (int i = 1; i <= files.Length; i++)
+            {
+                FileInfo fileinfo = new FileInfo(files[i - 1]);
+                if (i != files.Length)
+                {
+                    if (fileinfo.Name == "steam_api64.dll")
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        internal static bool IsEpic(string directory)
+        {
+            foreach (string dir in Directory.GetDirectories(directory))
+            {
+                DirectoryInfo dirInfo = new DirectoryInfo(dir);
+                if (dirInfo.Name == ".eggstore")
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        internal static bool IsMSStore(string directory)
+        {
+            string[] files = Directory.GetFiles(directory);
+            for (int i = 1; i <= files.Length; i++)
+            {
+                FileInfo fileinfo = new FileInfo(files[i - 1]);
+                if (i != files.Length)
+                {
+                    if (fileinfo.Name == "MicrosoftGame.config")
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        internal static bool NonValidStore(string folder)
+        {
+            string steamDll = Path.Combine(folder, PirateCheck.Steamapi);
+            if (File.Exists(steamDll))
+            {
+                FileInfo fileInfo = new FileInfo(steamDll);
+
+                if (fileInfo.Length > PirateCheck.Steamapilengh)
+                {
+                    return true;
+                }
+            }
+
+            foreach (string file in PirateCheck.CrackedFiles)
+            {
+                if (File.Exists(Path.Combine(folder, file)))
+                {
+                    return false;
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/QModManager/Patching/StoreDetector.cs
+++ b/QModManager/Patching/StoreDetector.cs
@@ -43,47 +43,30 @@
 
         internal static bool IsSteam(string directory)
         {
-            string[] files = Directory.GetFiles(directory);
-            for (int i = 1; i <= files.Length; i++)
+            string checkfile = Path.Combine(directory, "steam_api64.dll");
+            if (File.Exists(checkfile))
             {
-                FileInfo fileinfo = new FileInfo(files[i - 1]);
-                if (i != files.Length)
-                {
-                    if (fileinfo.Name == "steam_api64.dll")
-                    {
-                        return true;
-                    }
-                }
+                return true;
             }
             return false;
         }
 
         internal static bool IsEpic(string directory)
         {
-            foreach (string dir in Directory.GetDirectories(directory))
+            string checkfolder = Path.Combine(directory, ".eggstore");
+            if (Directory.Exists(checkfolder)
             {
-                DirectoryInfo dirInfo = new DirectoryInfo(dir);
-                if (dirInfo.Name == ".eggstore")
-                {
-                    return true;
-                }
+                return true;
             }
             return false;
         }
 
         internal static bool IsMSStore(string directory)
         {
-            string[] files = Directory.GetFiles(directory);
-            for (int i = 1; i <= files.Length; i++)
+            string checkfile = Path.Combine(directory, "MicrosoftGame.config");
+            if (File.Exists(checkfile))
             {
-                FileInfo fileinfo = new FileInfo(files[i - 1]);
-                if (i != files.Length)
-                {
-                    if (fileinfo.Name == "MicrosoftGame.config")
-                    {
-                        return true;
-                    }
-                }
+                return true;
             }
             return false;
         }

--- a/QModManager/Patching/StoreDetector.cs
+++ b/QModManager/Patching/StoreDetector.cs
@@ -54,7 +54,7 @@
         internal static bool IsEpic(string directory)
         {
             string checkfolder = Path.Combine(directory, ".eggstore");
-            if (Directory.Exists(checkfolder)
+            if (Directory.Exists(checkfolder))
             {
                 return true;
             }

--- a/QModManager/QModManager.csproj
+++ b/QModManager/QModManager.csproj
@@ -137,6 +137,7 @@
     <Compile Include="API\ModLoading\QModPatchAttributeBase.cs" />
     <Compile Include="Patching\QModPlaceholder.cs" />
     <Compile Include="Patching\QModPatchMethod.cs" />
+    <Compile Include="Patching\StoreDetector.cs" />
     <Compile Include="Utility\Config.cs" />
     <Compile Include="Utility\MainMenuMessages.cs" />
     <Compile Include="Utility\SummaryLogger.cs" />

--- a/QModManager/Utility/Dialog.cs
+++ b/QModManager/Utility/Dialog.cs
@@ -51,6 +51,12 @@
                     Process.Start(VersionCheck.bzNexus);
             });
 
+            internal static readonly Button Pirate = new Button("Close", () =>
+            {
+                Process.Start("https://www.youtube.com/watch?v=dQw4w9WgXcQ");
+                Application.Quit();
+            });
+
             internal Button() { }
             internal Button(string text, Action action)
             {


### PR DESCRIPTION
Adding a Store Detection for adding it into Logging.
Called before Fatal Error Exceptions to better indicate used Store without seeing Folder structur.
in addition could be indirect used as second Pirate check.

Warning was not able to test it myself properly.