### PR TITLE
Adding Modlist Tab to view all Loaded Mods

### DIFF
--- a/QModManager/OptionsManager.cs
+++ b/QModManager/OptionsManager.cs
@@ -6,10 +6,13 @@
     using QModManager.Utility;
     using System.Reflection;
     using UnityEngine.Events;
+    using System;
+    using System.IO;
 
     internal static class OptionsManager
     {
         internal static int ModsTab;
+        internal static int ModListTab;
 
         [HarmonyPatch(typeof(uGUI_OptionsPanel), nameof(uGUI_OptionsPanel.AddTabs))]
         internal static class OptionsPatch
@@ -17,10 +20,10 @@
             [HarmonyPostfix]
             internal static void Postfix(uGUI_OptionsPanel __instance)
             {
+                #region Mod Config
                 ModsTab = __instance.AddTab("Mods");
                 __instance.AddHeading(ModsTab, "QModManager");
 
-                
                 MethodInfo AddToggleOption = null; 
                 if(Patcher.CurrentlyRunningGame == QModGame.Subnautica)
                 {
@@ -60,7 +63,35 @@
                     AddToggleOption.Invoke(__instance, new object[] { ModsTab, "Enable debug logs", Config.EnableDebugLogs, new UnityAction<bool>(value => Config.EnableDebugLogs = value), null });
                     AddToggleOption.Invoke(__instance, new object[] { ModsTab, "Enable developer mode", Config.EnableDevMode, new UnityAction<bool>(value => Config.EnableDevMode = value), null });
                 }
+                #endregion Mod Config
 
+                #region Mod List
+                ModListTab = __instance.AddTab("Loaded Mods List");
+
+#if SUBNAUTICA_STABLE
+                __instance.AddHeading(ModListTab, $"QModManager Stable for Subnautica running version {Assembly.GetExecutingAssembly().GetName().Version.ToStringParsed()}");
+#elif SUBNAUTICA_EXP
+                __instance.AddHeading(ModListTab, $"QModManager Experimental for Subnautica running version {Assembly.GetExecutingAssembly().GetName().Version.ToStringParsed()}");
+#elif BELOWZERO_STABLE
+                __instance.AddHeading(ModListTab, $"QModManager Stable for Below Zero running version {Assembly.GetExecutingAssembly().GetName().Version.ToStringParsed()}");
+#elif BELOWZERO_EXP
+                __instance.AddHeading(ModListTab, $"QModManager Experimental for Below Zero running version {Assembly.GetExecutingAssembly().GetName().Version.ToStringParsed()}");
+#endif
+                __instance.AddHeading(ModListTab, $"- - List of currently running Mods - -");
+                var mods = QModServices.Main.GetAllMods();
+                int modsactivecounter = 0;
+
+                //Maybe add algorithm to sort Mods after Name
+                foreach (var mod in mods)
+                {
+                    if(mod.Enable)
+                    {
+                        __instance.AddHeading(ModListTab, $"{mod.DisplayName} version {mod.ParsedVersion.ToString()} from {mod.Author}");
+                        modsactivecounter++;
+                    }
+                }
+                __instance.AddHeading(ModListTab, $"Statistics: {modsactivecounter} Mods activated from {mods.Count} loaded");
+                #endregion Mod List
             }
         }
     }

--- a/QModManager/Patching/StoreDetector.cs
+++ b/QModManager/Patching/StoreDetector.cs
@@ -29,7 +29,7 @@
             }
             else if (IsEpic(directory))
             {
-                return "Eic Games";
+                return "Epic Games";
             }
             else if (IsMSStore(directory))
             {
@@ -88,7 +88,7 @@
             {
                 if (File.Exists(Path.Combine(folder, file)))
                 {
-                    return false;
+                    return true;
                 }
             }
             return false;


### PR DESCRIPTION
Sometimes people get confused why not all Mods are showing up in the Ingame Mod Menu.
So i added a List of all Mods loaded to the Game.
Also it displays the current QModManager Version.

Also i fixed a small error on the Store Detector.