### PR TITLE
Fixed BepInProcess for atleast one Mac BZ user

### DIFF
--- a/QModManager/BepInex/Plugins/LogFilter.cs
+++ b/QModManager/BepInex/Plugins/LogFilter.cs
@@ -8,7 +8,7 @@ namespace QModInstaller.BepInEx.Plugins
     /// Handles filtering noisy logs from the QModManager logs.
     /// </summary>
     [BepInPlugin(PluginGuid, PluginName, PluginVersion)]
-    [BepInProcess("Subnautica"), BepInProcess("SubnauticaZero")]
+    [BepInProcess("Subnautica"), BepInProcess("SubnauticaZero"), BepInProcess("Subnautica Below Zero")]
     internal class LogFilter : BaseUnityPlugin
     {
         internal const string PluginGuid = "QModManager.LogFilter";

--- a/QModManager/BepInex/Plugins/QMMLoader.cs
+++ b/QModManager/BepInex/Plugins/QMMLoader.cs
@@ -18,7 +18,7 @@ namespace QModInstaller.BepInEx.Plugins
     /// QMMLoader - simply fires up the QModManager entry point.
     /// </summary>
     [BepInPlugin(PluginGuid, PluginName, PluginVersion)]
-    [BepInProcess("Subnautica"), BepInProcess("SubnauticaZero")]
+    [BepInProcess("Subnautica"), BepInProcess("SubnauticaZero"), BepInProcess("Subnautica Below Zero")]
     public class QMMLoader : BaseUnityPlugin
     {
         internal const string PluginGuid = "QModManager.QMMLoader";


### PR DESCRIPTION
Had at least one user in discord have their BZ process name as "Subnautica Below Zero" which prevented the mods from loading. I'm not sure if this is common or a them specific issue but figured it was easy enough to support